### PR TITLE
Add basic Arabic HTML management pages

### DIFF
--- a/bonus.html
+++ b/bonus.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8">
+  <title>البونص</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js" defer></script>
+  <script defer>
+    function loadBonuses() {
+      const list = document.getElementById('bonus-list');
+      list.innerHTML = '';
+      const bonuses = JSON.parse(localStorage.getItem('bonuses') || '[]');
+      bonuses.forEach(b => {
+        const li = document.createElement('li');
+        li.textContent = `${b.name} (${b.job}): ${b.bonus}`;
+        list.appendChild(li);
+      });
+    }
+    function addBonus(evt) {
+      evt.preventDefault();
+      const name = document.getElementById('name').value;
+      const job = document.getElementById('job').value;
+      const salary = parseFloat(document.getElementById('salary').value) || 0;
+      const bonusAmount = salary * 0.1;
+      const bonuses = JSON.parse(localStorage.getItem('bonuses') || '[]');
+      bonuses.push({name, job, bonus: bonusAmount});
+      localStorage.setItem('bonuses', JSON.stringify(bonuses));
+      loadBonuses();
+      evt.target.reset();
+    }
+    document.addEventListener('DOMContentLoaded', loadBonuses);
+  </script>
+</head>
+<body>
+  <nav>
+    <a href="index.html">الرئيسية</a>
+  </nav>
+  <h1>البونص</h1>
+  <form onsubmit="addBonus(event)">
+    <label>اسم الموظف: <input id="name" required></label><br>
+    <label>الوظيفة: <input id="job" required></label><br>
+    <label>الراتب: <input id="salary" type="number" step="0.01" required></label><br>
+    <button type="submit">إضافة</button>
+  </form>
+  <ul id="bonus-list"></ul>
+</body>
+</html>

--- a/expenses.html
+++ b/expenses.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8">
+  <title>المصاريف</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js" defer></script>
+  <script defer>
+    function loadExpenses() {
+      const list = document.getElementById('expense-list');
+      list.innerHTML = '';
+      const expenses = JSON.parse(localStorage.getItem('expenses') || '[]');
+      expenses.forEach(e => {
+        const li = document.createElement('li');
+        li.textContent = `${e.desc}: ${e.amount}`;
+        list.appendChild(li);
+      });
+    }
+    function addExpense(evt) {
+      evt.preventDefault();
+      const desc = document.getElementById('desc').value;
+      const amount = parseFloat(document.getElementById('amount').value) || 0;
+      const expenses = JSON.parse(localStorage.getItem('expenses') || '[]');
+      expenses.push({desc, amount});
+      localStorage.setItem('expenses', JSON.stringify(expenses));
+      loadExpenses();
+      evt.target.reset();
+    }
+    document.addEventListener('DOMContentLoaded', loadExpenses);
+  </script>
+</head>
+<body>
+  <nav>
+    <a href="index.html">الرئيسية</a>
+  </nav>
+  <h1>المصاريف</h1>
+  <form onsubmit="addExpense(event)">
+    <label>الوصف: <input id="desc" required></label><br>
+    <label>المبلغ: <input id="amount" type="number" step="0.01" required></label><br>
+    <button type="submit">إضافة</button>
+  </form>
+  <ul id="expense-list"></ul>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8">
+  <title>الصفحة الرئيسية</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js" defer></script>
+</head>
+<body>
+  <nav>
+    <a href="sales.html">المبيعات</a>
+    <a href="expenses.html">المصاريف</a>
+    <a href="bonus.html">البونص</a>
+    <a href="settings.html">الإعدادات</a>
+  </nav>
+  <h1>مرحبا بكم</h1>
+  <p>اختر الصفحة المطلوبة من القائمة.</p>
+</body>
+</html>

--- a/sales.html
+++ b/sales.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8">
+  <title>المبيعات</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js" defer></script>
+  <script defer>
+    function updateTotal() {
+      const cash = parseFloat(document.getElementById('cash').value) || 0;
+      const network = parseFloat(document.getElementById('network').value) || 0;
+      document.getElementById('total').value = cash + network;
+    }
+  </script>
+</head>
+<body>
+  <nav>
+    <a href="index.html">الرئيسية</a>
+  </nav>
+  <h1>إدخال المبيعات</h1>
+  <form>
+    <label>كاش: <input id="cash" type="number" step="0.01" oninput="updateTotal()"></label><br>
+    <label>شبكة: <input id="network" type="number" step="0.01" oninput="updateTotal()"></label><br>
+    <label>المجموع: <input id="total" type="number" step="0.01" readonly></label>
+  </form>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,10 @@
+function applyTheme() {
+  const theme = localStorage.getItem('theme') || 'light';
+  if (theme === 'dark') {
+    document.body.classList.add('dark');
+  } else {
+    document.body.classList.remove('dark');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', applyTheme);

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="ar">
+<head>
+  <meta charset="UTF-8">
+  <title>الإعدادات</title>
+  <link rel="stylesheet" href="style.css">
+  <script src="script.js" defer></script>
+  <script defer>
+    function saveSettings(evt) {
+      evt.preventDefault();
+      const theme = document.querySelector('input[name="theme"]:checked').value;
+      localStorage.setItem('theme', theme);
+      applyTheme();
+    }
+    document.addEventListener('DOMContentLoaded', () => {
+      const current = localStorage.getItem('theme') || 'light';
+      document.getElementById(`theme-${current}`).checked = true;
+    });
+  </script>
+</head>
+<body>
+  <nav>
+    <a href="index.html">الرئيسية</a>
+  </nav>
+  <h1>الإعدادات</h1>
+  <form onsubmit="saveSettings(event)">
+    <p>اختر النمط:</p>
+    <label><input type="radio" id="theme-light" name="theme" value="light"> فاتح</label><br>
+    <label><input type="radio" id="theme-dark" name="theme" value="dark"> داكن</label><br>
+    <button type="submit">حفظ</button>
+  </form>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,13 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+nav a {
+  margin-right: 10px;
+}
+
+body.dark {
+  background-color: #333;
+  color: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- Add home page linking sales, expenses, bonus, and settings
- Implement sales entry with cash/network total calculation
- Allow adding expenses and bonuses with persistent storage
- Provide settings page to toggle light/dark theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952e858cd8832294277f07f3a63e18